### PR TITLE
Add ``conftest`` to the list of by default not grokked modules.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changes
 2.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Add ``conftest`` to the list of by default not grokked modules. It is used by
+  `py.test`.
 
 2.6 (2015-05-12)
 ----------------
@@ -13,11 +13,11 @@ Changes
 - compatibility for python 3
 - Python 3 doesn't support the directive ``zope.interface.implements``
   any more and is required to use the ``@implementer`` class decorator instead.
-  This version of grokcore.components provides its own 
+  This version of grokcore.components provides its own
   ``grokcore.component.implements`` directive for both Python 2 and 3.
   So this directive can still be used with the help of a grokker.
   If you use grokcore.components >= 2.6  the new implementation will be used
-  while earlier versions used zope.interface.implements.  
+  while earlier versions used zope.interface.implements.
 
 2.5 (2012-05-01)
 ----------------

--- a/src/grokcore/component/zcml.py
+++ b/src/grokcore/component/zcml.py
@@ -48,7 +48,7 @@ the_module_grokker = martian.ModuleGrokker(the_multi_grokker)
 
 
 def skip_tests(name):
-    return name in ['tests', 'ftests', 'testing']
+    return name in ['tests', 'ftests', 'testing', 'conftest']
 
 
 def grokDirective(_context, package, exclude=None):


### PR DESCRIPTION
 It is used by `py.test`.