### PR TITLE
Exclude multiple

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 2.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add ability to exclude more than one module or package using
+  ``<grok:grok exclude="<names>" />`` and allow to use unix shell-style
+  wildcards within.
 
 
 2.6.1 (2016-01-29)

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,10 @@ To sum up, your ``site.zcml`` file should look like something like this::
 
   </configure>
 
+There is an optional ``exclude`` on the `grok` directive. It allows to specify
+names of packages or modules that if encountered won't be grokked. These
+names might contain unix shell-style wildcards.
+
 Examples
 ========
 

--- a/src/grokcore/component/tests/test_grok.py
+++ b/src/grokcore/component/tests/test_grok.py
@@ -53,7 +53,7 @@ def suiteFromPackage(name):
 def test_suite():
     suite = unittest.TestSuite()
     for name in ['adapter', 'directive', 'grokker', 'utility', 'view',
-                 'event', 'inherit', 'order', 'subscriptions']:
+                 'event', 'inherit', 'order', 'subscriptions', 'zcml']:
         suite.addTest(suiteFromPackage(name))
 
     api = doctest.DocFileSuite('api.txt')

--- a/src/grokcore/component/tests/zcml/__init__.py
+++ b/src/grokcore/component/tests/zcml/__init__.py
@@ -1,0 +1,1 @@
+# this is a package

--- a/src/grokcore/component/tests/zcml/exclude.py
+++ b/src/grokcore/component/tests/zcml/exclude.py
@@ -1,0 +1,34 @@
+"""
+It allows to exclude a single package or module from beeing grokked.
+
+There is a NameError in `.excludepkg.sample` which is raised when this
+module is not excluded:
+
+>>> xmlconfig.string('''
+...     <configure xmlns:grok="http://namespaces.zope.org/grok">
+...       <include package="grokcore.component" file="meta.zcml"/>
+...       <grok:grok package="." />
+...     </configure>''', context)
+Traceback (most recent call last):
+ZopeXMLConfigurationError: File "<string>", line 4.6-4.31
+    NameError: name 'asdf' is not defined
+
+Excluding `.excludepkg.sample` via ZCML allows to successfully grok the
+module:
+
+>>> xmlconfig.string('''
+...     <configure xmlns:grok="http://namespaces.zope.org/grok">
+...       <include package="grokcore.component" file="meta.zcml"/>
+...       <grok:grok package="."
+...                  exclude="sample" />
+...     </configure>''', context)
+<zope.configuration.config.ConfigurationMachine ...>
+
+"""
+
+from zope.configuration import xmlconfig
+from grokcore.component.tests.zcml import excludepkg
+
+context = xmlconfig.ConfigurationMachine()
+xmlconfig.registerCommonDirectives(context)
+context.package = excludepkg

--- a/src/grokcore/component/tests/zcml/excludemany.py
+++ b/src/grokcore/component/tests/zcml/excludemany.py
@@ -1,0 +1,50 @@
+"""
+It allows to exclude a many packages or modules from beeing grokked.
+
+These packages or modules can be specified using unix shell-style wildcards
+
+There is a NameError in `.excludemanypkg.file_1` which is raised when this
+module is not excluded:
+
+>>> xmlconfig.string('''
+...     <configure xmlns:grok="http://namespaces.zope.org/grok">
+...       <include package="grokcore.component" file="meta.zcml"/>
+...       <grok:grok package="." />
+...     </configure>''', context)
+Traceback (most recent call last):
+ZopeXMLConfigurationError: File "<string>", line 4.6-4.31
+    NameError: name 'asdf' is not defined
+
+There is a NameError in `.excludemanypkg.test_asdf`, too which is raised when
+this module is not excluded:
+
+>>> xmlconfig.string('''
+...     <configure xmlns:grok="http://namespaces.zope.org/grok">
+...       <include package="grokcore.component" file="meta.zcml"/>
+...       <grok:grok package="."
+...                  exclude="file_*" />
+...     </configure>''', context)
+Traceback (most recent call last):
+ZopeXMLConfigurationError: File "<string>", line 4.6-5.36
+    NameError: name 'qwe' is not defined
+
+
+Excluding both 'file_1` and `test_asdf`allows to successfully grok the module:
+
+>>> xmlconfig.string('''
+...     <configure xmlns:grok="http://namespaces.zope.org/grok">
+...       <include package="grokcore.component" file="meta.zcml"/>
+...       <grok:grok package="."
+...                  exclude="file_*
+...                           *asdf" />
+...     </configure>''', context)
+<zope.configuration.config.ConfigurationMachine ...>
+
+"""
+
+from zope.configuration import xmlconfig
+from grokcore.component.tests.zcml import excludemanypkg
+
+context = xmlconfig.ConfigurationMachine()
+xmlconfig.registerCommonDirectives(context)
+context.package = excludemanypkg

--- a/src/grokcore/component/tests/zcml/excludemanypkg/__init__.py
+++ b/src/grokcore/component/tests/zcml/excludemanypkg/__init__.py
@@ -1,0 +1,1 @@
+# this is a package

--- a/src/grokcore/component/tests/zcml/excludemanypkg/file_1.py
+++ b/src/grokcore/component/tests/zcml/excludemanypkg/file_1.py
@@ -1,0 +1,1 @@
+asdf  # This leads to a NameError if exclude does not work correctly.

--- a/src/grokcore/component/tests/zcml/excludemanypkg/test_asdf.py
+++ b/src/grokcore/component/tests/zcml/excludemanypkg/test_asdf.py
@@ -1,0 +1,1 @@
+qwe  # This leads to a NameError if exclude does not work correctly.

--- a/src/grokcore/component/tests/zcml/excludepkg/__init__.py
+++ b/src/grokcore/component/tests/zcml/excludepkg/__init__.py
@@ -1,0 +1,1 @@
+# this is a package

--- a/src/grokcore/component/tests/zcml/excludepkg/sample.py
+++ b/src/grokcore/component/tests/zcml/excludepkg/sample.py
@@ -1,0 +1,1 @@
+asdf  # This leads to a NameError if exclude does not work correctly.


### PR DESCRIPTION
Add the ability to exclude more than one module or package using ``<grok:grok exclude="<names>" />`` and allow to use unix shell-style wildcards within.

Added a test for the exclude feature before this change (see separate commit), too.