### PR TITLE
Upgrade to support `zope.interface >= 6.0`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,15 +4,19 @@ Changes
 4.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Upgrade to support ``zope.interface >= 6.0`` by no longer importing removed
+  functions:
+
+    + ``classProvides``
+    + ``implementsOnly``
 
 
 4.0 (2023-02-17)
 ----------------
 
-* Add support for Python 3.10, 3.11.
+- Add support for Python 3.10, 3.11.
 
-* Drop support for Python 2.7, 3.5, 3.6.
+- Drop support for Python 2.7, 3.5, 3.6.
 
 
 3.2.0 (2021-03-22)

--- a/src/grokcore/component/__init__.py
+++ b/src/grokcore/component/__init__.py
@@ -23,8 +23,6 @@ from martian import ignore
 from martian.error import GrokError
 from martian.error import GrokImportError
 from zope.component import adapts
-from zope.interface import classProvides
-from zope.interface import implementsOnly
 
 # Import this module so that it's available as soon as you import the
 # 'grokcore.component' package.  Useful for tests and interpreter examples.

--- a/src/grokcore/component/decorators.py
+++ b/src/grokcore/component/decorators.py
@@ -20,7 +20,6 @@ import zope.component
 import zope.interface
 from martian.error import GrokImportError
 from martian.util import frame_is_module
-from zope.interface.declarations import DescriptorAwareMetaClasses
 
 
 class subscribe:
@@ -106,7 +105,7 @@ class implementer(zope.interface.implementer):
     """
 
     def __call__(self, ob):
-        if not isinstance(ob, DescriptorAwareMetaClasses):
+        if not isinstance(ob, type):
             frame = sys._getframe(1)
             adapters = frame.f_locals.get('__grok_adapters__', None)
             if adapters is None:
@@ -127,7 +126,7 @@ class provider:
         self.interfaces = interfaces
 
     def __call__(self, ob):
-        if isinstance(ob, DescriptorAwareMetaClasses):
+        if isinstance(ob, type):
             raise TypeError("Can't use implementer with classes.  Use one of "
                             "the class-declaration functions instead.")
         zope.interface.alsoProvides(ob, *self.interfaces)

--- a/src/grokcore/component/interfaces.py
+++ b/src/grokcore/component/interfaces.py
@@ -72,17 +72,6 @@ class IDirectives(Interface):
     def implements(*interfaces):
         """Declare that a class implements the given interfaces."""
 
-    def implementsOnly(*interfaces):
-        """Declare that a class implements only the given interfaces.
-
-        Interfaces implemented by base classes are explicitly not inherited.
-        """
-
-    def classProvides(*interfaces):
-        """Declare that a class (as opposed to instances of the class)
-        directly provides the given interfaces.
-        """
-
     def adapts(*classes_or_interfaces):
         """Declare that a class adapts objects of the given classes or
         interfaces."""


### PR DESCRIPTION
Removed importing no longer existing functions:

- classProvides
- implementsOnly

These function were deprecated in `zope.interface` and got removed in version 6.0, see https://pypi.org/project/zope.interface/